### PR TITLE
Update reference link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A “source” is a JSON file describing your episodes. It must follow this stru
     - **`title`**: Episode title shown in the menu.
     - **`src`**: Public URL to the video file (must support CORS).
 
-For refrence, see Directorys/ExampleDir.json
+For reference, see Directorys/Files/ExampleDir.json
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- fix reference path in README to point to Directorys/Files/ExampleDir.json

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689b643e6ea08331b5ab7f26b38bbdb7