### PR TITLE
Fix item URL parameter handling in loadVideo

### DIFF
--- a/script.js
+++ b/script.js
@@ -139,9 +139,9 @@ function loadVideo(index) {
   video.play();
   // Update the URL to reflect the current episode index
   const params = new URLSearchParams(window.location.search);
-  // Preserve or update existing '?item' key if present, otherwise use 'item'
-  if (params.has('?item')) {
-    params.set('?item', index + 1);
+  // Preserve or update existing 'item' key if present, otherwise set it
+  if (params.has('item')) {
+    params.set('item', index + 1);
   } else {
     params.set('item', index + 1);
   }


### PR DESCRIPTION
## Summary
- Correct URL parameter handling by using 'item' consistently in `loadVideo`
- Update comment to describe the 'item' key

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b64355d6c8331b281e60209a84cd7