### PR TITLE
Fix typo in tab button CSS property

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
       border: none;
       border-radius: 6px;
       cursor: pointer;
-      text-tra0nsform: uppercase;
+      text-transform: uppercase;
       letter-spacing: 0.5px;
       transition: background 0.2s, transform 0.1s;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;


### PR DESCRIPTION
## Summary
- Correct a typo in the `.tab-button` CSS rule to properly use `text-transform`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b642a3bfc8331ab5c6440694f1388