### PR TITLE
fix: auto-open single-item movie sources

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -247,7 +247,7 @@ async function loadSource(rawInput) {
     directoryTitle.style.display = 'block';
     selectorScreen.style.display = 'flex';
     renderEpisodeList();
-    showResumeMessage();
+    if (!openSingleItemMovieSource()) showResumeMessage();
     setRecentSourcesActive(true);
     if (window.RSPRecentSources && typeof window.RSPRecentSources.record === 'function') {
       try {

--- a/scripts/list.js
+++ b/scripts/list.js
@@ -221,6 +221,29 @@ function isMovieCategory(category) {
   return /\bmovie\b/i.test(title);
 }
 
+function openSingleItemMovieSource() {
+  if (!Array.isArray(videoList) || videoList.length !== 1) return false;
+  const category = videoList[0];
+  const episodes = Array.isArray(category && category.episodes) ? category.episodes : [];
+  if (!isMovieCategory(category) || episodes.length !== 1 || !Array.isArray(flatList) || flatList.length !== 1) {
+    return false;
+  }
+
+  const entry = flatList[0];
+  if (!entry || entry.isPlaceholder) return false;
+
+  const resumeKey = resolveResumeKeyForItem(entry);
+  if (resumeKey) localStorage.setItem('lastEpSrc', resumeKey);
+  writeSourceScopedValue('SavedItem', '0');
+  currentIndex = 0;
+  selectorScreen.style.display = 'none';
+  playerScreen.style.display = 'block';
+  backBtn.style.display = 'inline-block';
+  theaterBtn.style.display = 'inline-block';
+  loadVideo(currentIndex);
+  return true;
+}
+
 function buildSeparatedResumeKey(startIndex) {
   const base = (sourceKey && typeof sourceKey === 'string' && sourceKey.trim()) ? sourceKey.trim() : 'source';
   return `separated:${base}:${startIndex}`;

--- a/scripts/local-folder.js
+++ b/scripts/local-folder.js
@@ -323,7 +323,7 @@ async function handleExtractedFiles(files) {
   urlInputContainer.style.display = "none";
   selectorScreen.style.display = "flex";
   renderEpisodeList();
-  showResumeMessage();
+  if (!openSingleItemMovieSource()) showResumeMessage();
   if (window.RSPRecentSources && typeof window.RSPRecentSources.setSourceActive === 'function') {
     try { window.RSPRecentSources.setSourceActive(true); } catch {}
   }


### PR DESCRIPTION
Single-category sources explicitly marked as Movie now launch their sole available item immediately after loading. Normal shows, multi-item movie sources, mixed series/movie manifests, and unavailable placeholders continue to show the selector.

Validation:
- JavaScript syntax checks passed
- focused five-case behavior test passed
- live Backrooms test opened the player directly with its media URL
- live Roshidere test preserved the 12-item selector